### PR TITLE
Fix: Add Transaction Form does not clear fields when a transaction is added to Firebase

### DIFF
--- a/my-money/src/hooks/useFirestore.js
+++ b/my-money/src/hooks/useFirestore.js
@@ -34,7 +34,7 @@ export const useFirestore = (collection) => {
   }
 
   useEffect(() => {
-    return () => setIsCancelled(true)
+    return () => setIsCancelled(false)
   }, [])
 
   return { addDocument, deleteDocument, response }


### PR DESCRIPTION
Fix: Add Transaction Form does not clear fields when a transaction is successfully submitted to Firebase DB

`setIsCancelled()` should set the `isCancelled` state to the default of `false` inside the cleanup function.
