### PR TITLE
missing "{}" to list ingredients

### DIFF
--- a/cooking-ninja/src/pages/recipe/Recipe.js
+++ b/cooking-ninja/src/pages/recipe/Recipe.js
@@ -18,7 +18,7 @@ export default function Recipe() {
           <h2 className="page-title">{recipe.title}</h2>
           <p>Takes {recipe.cookingTime} to cook.</p>
           <ul>
-            {recipe.ingredients.map(ing => <li key={ing}>ing</li>)}
+            {recipe.ingredients.map(ing => <li key={ing}>{ing}</li>)}
           </ul>
           <p className="method">{recipe.method}</p>
         </>


### PR DESCRIPTION
There is a small typo, "{ }" are missing around the "ing" on line 21 in the "li" tag.

Thank you for the amazing content :) , you are my hero.